### PR TITLE
moved to radix tree implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/matryer/way
+
+go 1.19

--- a/param.go
+++ b/param.go
@@ -1,0 +1,57 @@
+package way
+
+import (
+	"context"
+	"sync"
+)
+
+type param struct{ key, value string }
+
+type paramPool struct {
+	pool *sync.Pool
+}
+
+func (p paramPool) Get() *[]param {
+	params := p.pool.Get().(*[]param)
+	*params = (*params)[:0]
+	return params
+}
+
+func (p paramPool) Put(params *[]param) {
+	if params == nil {
+		return
+	}
+	p.pool.Put(params)
+}
+
+var parpool = paramPool{
+	pool: &sync.Pool{New: func() interface{} {
+		p := make([]param, 12)
+		return &p
+	}},
+}
+
+type paramkey struct{}
+
+func toParamContext(ctx context.Context, params *[]param) context.Context {
+	return context.WithValue(ctx, paramkey{}, params)
+}
+
+// Param gets the path parameter from the specified Context.
+// Returns an empty string if the parameter was not found.
+func Param(ctx context.Context, key string) string {
+	if ctx == nil {
+		return ""
+	}
+	params, _ := ctx.Value(paramkey{}).(*[]param)
+	if params == nil {
+		return ""
+	}
+
+	for _, param := range *params {
+		if param.key == key {
+			return param.value
+		}
+	}
+	return ""
+}

--- a/tree.go
+++ b/tree.go
@@ -1,0 +1,248 @@
+package way
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	static = iota
+	wildcard
+)
+
+var errMultipleRegistrations = errors.New("multiple registrations")
+
+type node struct {
+	Key      string
+	Value    map[string]http.Handler
+	Children []*node
+	Indices  []byte
+	Wildcard *node
+	Type     int
+}
+
+type methodBoundHandler struct {
+	method  string
+	handler http.Handler
+}
+
+func (mh *methodBoundHandler) asMap() map[string]http.Handler {
+	if mh == nil {
+		return nil
+	}
+	return map[string]http.Handler{mh.method: mh.handler}
+}
+
+func (n *node) Insert(key string, value *methodBoundHandler) error {
+	idx := strings.IndexAny(key, ":*")
+	if idx == -1 {
+		_, err := n.insert(key, value)
+		return err
+	}
+
+	pre := key[:idx]
+
+	n, err := n.insert(pre, nil)
+	if err != nil {
+		return err
+	}
+
+	post := key[idx:]
+
+	slashIdx := strings.IndexByte(post, '/')
+	if slashIdx == -1 {
+		_, err := n.insert(post, value)
+		return err
+	}
+
+	n, err = n.insert(post[:slashIdx], nil)
+	if err != nil {
+		return err
+	}
+
+	return n.Insert(post[slashIdx:], value)
+}
+
+func (n *node) insert(key string, value *methodBoundHandler) (*node, error) {
+	switch key[0] {
+	case ':':
+		if n.Wildcard != nil {
+			if n.Wildcard.Key != key[1:] {
+				return nil, fmt.Errorf("mismatched wild cards :%s and %s", n.Wildcard.Key, key)
+			}
+			if value != nil {
+				if n.Wildcard.Value == nil {
+					n.Wildcard.Value = make(map[string]http.Handler)
+				}
+				if n.Wildcard.Value[value.method] != nil {
+					return nil, errMultipleRegistrations
+				}
+				n.Wildcard.Value[value.method] = value.handler
+
+			}
+			return n.Wildcard, nil
+		}
+
+		n.Wildcard = &node{
+			Key:   key[1:],
+			Value: value.asMap(),
+			Type:  wildcard,
+		}
+
+		return n.Wildcard, nil
+	}
+
+	for i, childNode := range n.Children {
+		if key == childNode.Key {
+			if value != nil {
+				if childNode.Value == nil {
+					childNode.Value = make(map[string]http.Handler)
+				}
+				if childNode.Value[value.method] != nil {
+					return nil, errMultipleRegistrations
+				}
+				childNode.Value[value.method] = value.handler
+			}
+			return childNode, nil
+		}
+
+		cp := commonPrefixLength(childNode.Key, key)
+		if cp == 0 {
+			continue
+		}
+
+		if cp == len(childNode.Key) {
+			return childNode.insert(key[cp:], value)
+		}
+
+		childNode.Key = childNode.Key[cp:]
+
+		if cp == len(key) {
+			n.Children[i] = &node{
+				Key:      key,
+				Children: []*node{childNode},
+				Indices:  []byte{childNode.Key[0]},
+				Value:    value.asMap(),
+			}
+			return n.Children[i], nil
+		}
+
+		targetNode := &node{
+			Key:      key[cp:],
+			Children: []*node{},
+			Value:    value.asMap(),
+		}
+
+		n.Children[i] = &node{
+			Key:      key[:cp],
+			Children: []*node{childNode, targetNode},
+			Indices:  []byte{childNode.Key[0], targetNode.Key[0]},
+		}
+
+		return targetNode, nil
+	}
+
+	targetNode := &node{
+		Key:      key,
+		Children: []*node{},
+		Value:    value.asMap(),
+	}
+
+	n.Children = append(n.Children, targetNode)
+	n.Indices = append(n.Indices, targetNode.Key[0])
+
+	return targetNode, nil
+}
+
+func (n *node) Lookup(path string, params *[]param) (result map[string]http.Handler) {
+	var fallback map[string]http.Handler
+	defer func() {
+		if result == nil {
+			result = fallback
+		}
+	}()
+
+	var wildcardbackup *node
+
+Walk:
+	for {
+		switch n.Type {
+		case static:
+			if !strings.HasPrefix(path, n.Key) {
+				if wildcardbackup != nil {
+					n = wildcardbackup
+					continue Walk
+				}
+				if n.Value != nil && path+"/" == n.Key {
+					return n.Value
+				}
+				return nil
+			}
+			path = path[len(n.Key):]
+			if path == "" {
+				return n.Value
+			}
+			if n.IsSubdirNode() {
+				fallback = n.Value
+			}
+		case wildcard:
+			if idx := strings.IndexByte(path, '/'); idx == -1 {
+				*params = append(*params, param{
+					key:   n.Key,
+					value: path,
+				})
+				return n.Value
+			} else {
+				*params = append(*params, param{
+					key:   n.Key,
+					value: path[:idx],
+				})
+				path = path[idx:]
+			}
+
+		}
+
+		if path == "/" && n.Value != nil {
+			fallback = n.Value
+		}
+
+		wildcardbackup = n.Wildcard
+
+		targetIndice := path[0]
+		for i, c := range n.Indices {
+			if c == targetIndice {
+				n = n.Children[i]
+				continue Walk
+			}
+		}
+
+		if n.Wildcard != nil {
+			n = n.Wildcard
+			continue Walk
+		}
+
+		return nil
+	}
+}
+
+func (node *node) IsSubdirNode() bool {
+	return node != nil && node.Value != nil && strings.HasSuffix(node.Key, "/")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func commonPrefixLength(a, b string) (i int) {
+	for ; i < min(len(a), len(b)); i++ {
+		if a[i] != b[i] {
+			break
+		}
+	}
+	return
+}


### PR DESCRIPTION
Hi Mat!

(I have to get it out of the way, I am a big fan of your work)

I am opening this PR in regards to your open [issue](https://github.com/matryer/way/issues/1).

I am the author of [muxter](https://github.com/davidmdm/muxter) which is my personal hobby router project that I have made just as fast as other mainstream routers like gin, echo, httprouter and so on.

I have ported muxter's radix tree implementation over to way to help with the performance issues.

Unfortunately because of the API it cannot be as fast as muxter or other routers because modifying the request context forces context and request allocations, which is why other routers commonly have a different signature for their handlers.

However there should still be a significant speed up since all params are now put into the context in a single call.

I haven't touched the API, and all the tests are still passing, but I did make the project a go module which may merit a V2 should you decide to use this. 


Best of luck!